### PR TITLE
Add a task to destroy the test user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/mako-ai/messenger-bot-test-pipeline.svg?branch=master)](https://travis-ci.com/mako-ai/messenger-bot-test-pipeline)
+[![Build Status](https://travis-ci.com/mako-ai/ansible-role-facebook-messenger.svg?branch=master)](https://travis-ci.com/mako-ai/ansible-role-facebook-messenger)
 
 ## Variables
 
@@ -15,7 +15,6 @@
 - `graph_subscription_callback_url`
 - `graph_subscription_fields`
 - `graph_subscription_object`
-- `graph_subscription_verify_token`
 
 **User Variables**
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,5 @@
 [defaults]
 
+fact_caching = jsonfile
+fact_caching_connection = /tmp
 roles_path = ../

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-access_token: "{{ [ansible_env.FACEBOOK_APP_ID, ansible_env.FACEBOOK_APP_SECRET] | join('|') }}"
+graph_access_token: "{{ [ansible_env.FACEBOOK_APP_ID, ansible_env.FACEBOOK_APP_SECRET] | join('|') }}"
 # Changing the value of this token is permitted.
-verify_token: my-token
-version: v2.12
+graph_verify_token: my-token
+graph_version: v2.12

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   uri:
     body: |
       {
-        "access_token": "{{ access_token }}",
+        "access_token": "{{ graph_access_token }}",
         "permissions": "{{ graph_user_permissions | join(',') }}"
       }
     body_format: json
@@ -17,10 +17,11 @@
       Accept: application/json
     method: POST
     return_content: yes
-    url: https://graph.facebook.com/{{ version }}/{{ ansible_env.FACEBOOK_APP_ID }}/accounts/test-users
+    url: https://graph.facebook.com/{{ graph_version }}/{{ ansible_env.FACEBOOK_APP_ID }}/accounts/test-users
   register: response
 
 - set_fact:
+    cacheable: yes
     user:
       access_token: "{{ response.json.access_token }}"
       id: "{{ response.json.id }}"
@@ -46,7 +47,7 @@
       Accept: application/json
     method: POST
     return_content: yes
-    url: https://graph.facebook.com/{{ version }}/{{ user.id }}/accounts
+    url: https://graph.facebook.com/{{ graph_version }}/{{ user.id }}/accounts
 
 # https://developers.facebook.com/docs/graph-api/reference/v3.0/app/accounts/test-users#read
 - name: Retrieve the accounts associated with the test user
@@ -55,7 +56,7 @@
       Accept: application/json
     method: GET
     return_content: yes
-    url: https://graph.facebook.com/{{ version }}/me/accounts?access_token={{ user.access_token }}
+    url: https://graph.facebook.com/{{ graph_version }}/me/accounts?access_token={{ user.access_token }}
   register: response
 
 - set_fact:
@@ -78,7 +79,7 @@
       Accept: application/json
     method: POST
     return_content: yes
-    url: https://graph.facebook.com/{{ version }}/{{ page.id }}/subscribed_apps
+    url: https://graph.facebook.com/{{ graph_version }}/{{ page.id }}/subscribed_apps
   failed_when: not response.json.success
   register: response
 
@@ -87,18 +88,18 @@
   uri:
     body: |
       {
-        "access_token": "{{ access_token }}",
+        "access_token": "{{ graph_access_token }}",
         "callback_url": "{{ graph_subscription_callback_url }}",
         "fields": "{{ graph_subscription_fields | join(',') }}",
         "object": "{{ graph_subscription_object }}",
-        "verify_token": "{{ graph_subscription_verify_token }}"
+        "verify_token": "{{ graph_verify_token }}"
       }
     body_format: json
     headers:
       Accept: application/json
     method: POST
     return_content: yes
-    url: https://graph.facebook.com/{{ version }}/{{ ansible_env.FACEBOOK_APP_ID }}/subscriptions
+    url: https://graph.facebook.com/{{ graph_version }}/{{ ansible_env.FACEBOOK_APP_ID }}/subscriptions
   delay: 10
   register: response
   retries: 10
@@ -110,7 +111,7 @@
     body: |
       {
         "client_id": "{{ ansible_env.FACEBOOK_APP_ID }}",
-        "client_secret": "{{ access_token.split('|')[-1] }}",
+        "client_secret": "{{ graph_access_token.split('|')[-1] }}",
         "fb_exchange_token": "{{ page.access_token }}",
         "grant_type": "fb_exchange_token"
       }
@@ -119,29 +120,24 @@
       Accept: application/json
     method: POST
     return_content: yes
-    url: https://graph.facebook.com/{{ version }}/oauth/access_token
+    url: https://graph.facebook.com/{{ graph_version }}/oauth/access_token
   register: response
-
-# https://devcenter.heroku.com/articles/platform-api-reference#config-vars-update
-- name: Write the application access token and application verify token to Heroku configuration variables
-  uri:
-    body: |
-      {
-        "ACCESS_TOKEN": "{{ response.json.access_token }}",
-        "VERIFY_TOKEN": "{{ verify_token }}"
-      }
-    body_format: json
-    headers:
-      Accept: application/vnd.heroku+json; version=3
-      Authorization: Bearer {{ ansible_env.HEROKU_API_KEY }}
-      Content-Type: application/json
-    method: PATCH
-    return_content: yes
-    url: https://api.heroku.com/apps/{{ heroku_app_name }}/config-vars
-  when:
-    - response.json is defined
-    - ansible_env.HEROKU_API_KEY is not none
-    - heroku_app_name is not none
 
 - debug:
     msg: "{{ lookup('template', 'output.j2') }}"
+
+  # Prevent these tasks from running unless explicitly requested.
+- name: Destroy the test user
+  uri:
+    body: |
+     {
+      "access_token": "{{ graph_access_token }}"
+     }
+    body_format: json
+    headers:
+      Accept: application/json
+    method: DELETE
+    url: https://graph.facebook.com/{{ graph_version }}/{{ user.id }}
+  tags:
+    - destroy
+    - never

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,7 @@
 ---
 
 - connection: local
+  gather_facts: yes
   hosts: localhost
   remote_user: root
   roles:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,12 +12,9 @@ graph_subscription_fields:
   - messaging_optins
   - messaging_postbacks
 graph_subscription_object: page
-graph_subscription_verify_token: "{{ verify_token }}"
 
 graph_user_permissions:
   - manage_pages
   - pages_messaging
   - publish_actions
   - publish_pages
-
-heroku_app_name: ~


### PR DESCRIPTION
**Verification Steps:**

    $ ansible-playbook -i tests/inventory tests/test.yml -e 'graph_subscription_callback_url=https://immune-doe-staging-pr-49.herokuapp.com/facebook/receive'

    $ ansible-playbook -i tests/inventory tests/test.yml -e 'graph_subscription_callback_url=https://immune-doe-staging-pr-49.herokuapp.com/facebook/receive' --tags destroy

Visit the test users for the [review application](https://developers.facebook.com/apps/2186735398249287/roles/test-users/). Make sure that a user is created and matches the ID of the output of the `debug` statement. After running the playbook with `--tags destroy`, make sure that the test user is no longer present.

Closes #1

Signed-off-by: jasonwalsh <rightlag@gmail.com>